### PR TITLE
Positive Chat!

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -41,6 +41,12 @@
 			"default": "",
 			"description": "list of custom chatters that u want added to the chat seperated by spaces"
 		},
+		"positive-chat": {
+			"type": "bool",
+			"name": "Positive Chat",
+			"description": "Makes the chat more positive! We need more positivity around here :)\n\n<cb>Feature by XblazeGMD</c>",
+			"default": false
+		},
 		"x-off": {
 			"name": "Chat x offset",
 			"type": "int",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,6 +219,7 @@ class $modify(MyPlayLayer, PlayLayer) {
         float ggPercent = 99.9999f;
         int att = 0;
         bool enabled = false;
+        bool m_positiveChat = false;
         bool m_echoClipPresent = false;
         bool m_clipMessageFired = false;
         float m_bestPercent = 0.0f;
@@ -240,6 +241,7 @@ public:
         fields->superGoPercent = loadPercentForLevel(m_level->m_levelID, "supergo-percent", 80.0f);
         fields->ggPercent = loadPercentForLevel(m_level->m_levelID, "gg-percent", 99.9999f);
         fields->enabled = loadDisabledForLevel(m_level->m_levelID, "enabled", !Mod::get()->getSettingValue<bool>("enabled-by-default"));
+        fields->m_positiveChat = Mod::get()->getSettingValue<bool>("positive-chat");
         fields->m_numViewers = Mod::get()->getSettingValue<int>("viewer-count");
         fields->m_font = Mod::get()->getSettingValue<std::string>("font") + ".fnt";
         fields->m_opacity = Mod::get()->getSettingValue<float>("opacity");
@@ -432,28 +434,59 @@ public:
             } else if (fields->m_lastAttPercent <= (float)fields->m_lvl->getNormalPercent()) {
                 fields->m_randomChatTimer += dt;
                 if (fields->m_randomChatTimer >= fields->m_nextChatDelay) {
-                    std::vector<std::string> deathMessages = {
-                        chat("RIP"),
-                        chat("NOOOO"),
-                        chat("rippp"),
-                        chat("F"),
-                        chat("NOOOOOO"),
-                        chat("rip bozo"),
-                        chat("oof"),
-                        chat("so close"),
-                        chat("unlucky"),
-                        chat("F in chat"),
-                        chat("rip"),
-                        chat("noooo way"),
-                        chat("bro"),
-                        chat("that was so close"),
-                        chat("NOOOOOOOOOO"),
-                        chat("next attempt"),
-                        chat("you had it"),
-                        chat("almost"),
-                        chat("not like this"),
-                        chat("gg attempt"),
-                    };
+                    std::vector<std::string> deathMessages;
+                    if (m_fields->m_positiveChat) {
+                        // a more positive chat!
+                        deathMessages = {
+                            chat("W"),
+                            chat("WWWW"),
+                            chat("W RUN"),
+                            chat("Nice run!"),
+                            chat("W W W W W"),
+                            chat("NICE!"),
+                            chat("BRO YOU'RE SO GOOD"),
+                            chat("YOU'RE THE GOAT"),
+                            chat("Next Zoink fr?"),
+                            chat("YESSSS"),
+                            chat("WWWWWWWWWWWW"),
+                            chat("NOOOOOOOOOO"), // cuz even the most positive chat will have someone sad
+                            chat("dang it"),
+                            chat("nice!"),
+                            chat("consistency is key"),
+                            chat("crap"),
+                            chat("rip bozo"),
+                            chat("so close"),
+                            chat("nice attempt"),
+                            chat("gg attempt"),
+                            chat("skill issue :p"),
+                        };
+                    } else {
+                        // your usual chat
+                        deathMessages = {
+                            chat("RIP"),
+                            chat("NOOOO"),
+                            chat("rippp"),
+                            chat("F"),
+                            chat("NOOOOOO"),
+                            chat("rip bozo"),
+                            chat("oof"),
+                            chat("so close"),
+                            chat("unlucky"),
+                            chat("F in chat"),
+                            chat("rip"),
+                            chat("noooo way"),
+                            chat("bro"),
+                            chat("that was so close"),
+                            chat("NOOOOOOOOOO"),
+                            chat("next attempt"),
+                            chat("you had it"),
+                            chat("almost"),
+                            chat("not like this"),
+                            chat("gg attempt"),
+                            chat("skill issue :p"), // may or may not have been added by xblaze... oh well
+                        };
+                    }
+
                     addChatMessage(deathMessages[rand() % deathMessages.size()]);
                     fields->m_randomChatTimer = 0;
                 }


### PR DESCRIPTION
I originally wanted to add this to my other PR but I decided against it so I added it here

The idea is simple: add a setting to make the chat more "positive"!

If the setting is enabled (which it isn't by default) then when you die instead of showing just some sad "negative" comments (e.g. "NOOOOOOOOO" "RIP", etc) they will instead be replaced with more "positive" comments intended to cheer you up a bit (e.g. "WWWWWWWW", "YOU'RE THE GOAT", etc). I think we need some positivity around here!

This is a random idea I had and I thought it would fit the mod well enough so yeah here we are